### PR TITLE
Raise the timeout to remove errors from the demo, and re-introduce cl…

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -14,7 +14,7 @@ func main() {
 	// Depending on how big of a mailbox you give your listeners,
 	// and how busy your publishers are, this number becomes very
 	// important to avoid bleeding messages through Err()
-	p := spub.New(time.Millisecond * 1)
+	p := spub.New(time.Second * 10)
 	// We'll use this to block on shutdown near the end
 	wg := sync.WaitGroup{}
 	// Dynamically control the number of subscribers to demonstrate parallelism

--- a/spub.go
+++ b/spub.go
@@ -82,8 +82,8 @@ func (p *Publisher) Broadcast(b []byte) {
 	for _, l := range p.subscribers {
 		// Fire off a goroutine
 		// Need to make a local copy, or else we run into closure conundrums
-		lx := l
-		go p.sendto(b, &lx)
+		//lx := l
+		go p.sendto(b, &l)
 	}
 	p.mu.Unlock()
 }


### PR DESCRIPTION
…osure issue to demonstrate problem

DO NOT MERGE

This is to demonstrate what happens when you don't make a local copy of something in a range before passing it as a pointer to a new go routine, which was brought up during my talk.